### PR TITLE
fix #DEVDESK-45

### DIFF
--- a/src/Maestrano.Tests/Api/MnoClientTest.cs
+++ b/src/Maestrano.Tests/Api/MnoClientTest.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Maestrano.Api;
+
+namespace Maestrano.Tests.Api
+{
+    [TestClass]
+    public class MnoClientTest
+    {
+        public class DateContainer
+        {
+            public DateTime Date { get; set; }
+            public DateTime IncorrectDate { get; set; }
+            public DateTime? IncorrectNullableDate { get; set; }
+        }
+
+        [TestMethod]
+        public void DeserializeObject_DeserializeDate()
+        {
+            string json = @"{'Date': '0001-01-01T00:00:00Z','IncorrectDate': '0000-01-01T00:00:00Z','IncorrectNullableDate': '-000-01-01T00:00:00Z'}";
+            var result = MnoClient.DeserializeObject<DateContainer>(json);
+            Assert.AreEqual(new DateTime(1,1,1), result.IncorrectDate);
+            Assert.AreEqual(DateTime.MinValue, result.IncorrectDate);
+            Assert.IsNull(result.IncorrectNullableDate);
+        }
+    }
+}

--- a/src/Maestrano.Tests/Connec/ClientTest.cs
+++ b/src/Maestrano.Tests/Connec/ClientTest.cs
@@ -84,7 +84,7 @@ namespace Maestrano.Tests.Connec
 
             Assert.IsNotNull(parsed["organizations"]);
             Assert.AreEqual(id, parsed["organizations"]["id"]);
-            Assert.AreEqual("True",parsed["organizations"]["is_customer"]);
+            Assert.AreEqual("true",parsed["organizations"]["is_customer"]);
         }
     }
 }

--- a/src/Maestrano.Tests/Maestrano.Tests.csproj
+++ b/src/Maestrano.Tests/Maestrano.Tests.csproj
@@ -54,12 +54,15 @@
     <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Moq">
       <HintPath>..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.core, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.dll</HintPath>
@@ -97,6 +100,7 @@
     <Compile Include="Account\GroupTest.cs" />
     <Compile Include="Account\UserWithPresetTest.cs" />
     <Compile Include="Account\UserTest.cs" />
+    <Compile Include="Api\MnoClientTest.cs" />
     <Compile Include="Connec\ClientTest.cs" />
     <Compile Include="Helpers\TimeZoneConverterTests.cs" />
     <Compile Include="MaestranoConfigurationWithPresetTests.cs" />
@@ -142,9 +146,7 @@
   <ItemGroup>
     <None Include="Support\Saml\Certificates\certificate1" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Api\" />
-  </ItemGroup>
+  <ItemGroup />
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
       <ItemGroup>

--- a/src/Maestrano.Tests/packages.config
+++ b/src/Maestrano.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
   <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net45" />
   <package id="RestSharp" version="104.4.0" targetFramework="net45" />

--- a/src/Maestrano/Api/CorrectedIsoDateTimeConverter.cs
+++ b/src/Maestrano/Api/CorrectedIsoDateTimeConverter.cs
@@ -1,0 +1,51 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Maestrano.Api
+{
+    /// <summary>
+    /// Corrected version of IsoDateTimeConverter that accept date written in ISO_8601 format with a negative or zero year
+    /// Since DateTime does not support such date, returns null or DateTime.MinValue depending if it is a DateTime? or DateTime that is deserialized
+    /// https://en.wikipedia.org/wiki/ISO_8601
+    /// </summary>
+    class CorrectedIsoDateTimeConverter : IsoDateTimeConverter
+    {
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.String)
+            {
+                string dateText = reader.Value.ToString();
+                if (dateText.StartsWith("0000") || dateText.StartsWith("-"))
+                {
+                    if (IsNullable(objectType))
+                    {
+                        return null;
+                    }
+                    else
+                    {
+                        return DateTime.MinValue;
+                    }
+
+                }
+            }
+            return base.ReadJson(reader, objectType, existingValue, serializer);
+        }
+        private static bool IsNullable(Type t)
+        {
+            if (t.IsValueType)
+            {
+                return (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(Nullable<>));
+            }
+            else
+            {
+                return true;
+            }
+        }
+    }
+}

--- a/src/Maestrano/Api/MnoClient.cs
+++ b/src/Maestrano/Api/MnoClient.cs
@@ -13,10 +13,11 @@ namespace Maestrano.Api
     public static class MnoClient
     {
         private static Dictionary<string, RestClient> clientDict;
-
+        private static JsonSerializerSettings jsonSerializerSettings = new JsonSerializerSettings();
         static MnoClient()
         {
             clientDict = new Dictionary<string, RestClient>();
+            jsonSerializerSettings.Converters.Add(new CorrectedIsoDateTimeConverter());
         }
 
         private static RestClient Client(string presetName = "maestrano")
@@ -56,13 +57,19 @@ namespace Maestrano.Api
             };
 
             var response = Client(presetName).Execute(request);
-            var respObj = JsonConvert.DeserializeObject<MnoObject<T>>(response.Content);
+            var respObj = DeserializeObject<MnoObject<T>>(response.Content);
             respObj.ThrowIfErrors();
             respObj.AssignPreset(presetName);
 
             return respObj.Data;
         }
-
+        /// <summary>
+        /// Deserializes the JSON to the specified .NET type
+        /// </summary>
+        public static U DeserializeObject<U>(string s)
+        {
+            return JsonConvert.DeserializeObject<U>(s, jsonSerializerSettings);
+        }
         /// <summary>
         /// Execute a manual REST request
         /// </summary>
@@ -79,7 +86,7 @@ namespace Maestrano.Api
             };
 
             var response = Client(presetName).Execute(request);
-            var respObj = JsonConvert.DeserializeObject<MnoCollection<T>>(response.Content);
+            var respObj = DeserializeObject<MnoCollection<T>>(response.Content);
             respObj.ThrowIfErrors();
             respObj.AssignPreset(presetName);
 

--- a/src/Maestrano/Maestrano.csproj
+++ b/src/Maestrano/Maestrano.csproj
@@ -52,9 +52,9 @@
     <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.core, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.dll</HintPath>
@@ -98,6 +98,7 @@
     <Compile Include="Account\RecurringBillRequestor.cs" />
     <Compile Include="Account\User.cs" />
     <Compile Include="Account\UserRequestor.cs" />
+    <Compile Include="Api\CorrectedIsoDateTimeConverter.cs" />
     <Compile Include="Api\MnoClient.cs" />
     <Compile Include="Api\MnoCollection.cs" />
     <Compile Include="Api\MnoObject.cs" />

--- a/src/Maestrano/packages.config
+++ b/src/Maestrano/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.4" />
+  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
   <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net45" />
   <package id="RestSharp" version="104.4.0" />
 </packages>


### PR DESCRIPTION
Fix error "Could not convert string to DateTime: 0000-01-01T00:00:00Z. Path 'data.free_trial_end_at', line 1, position 264."
Update Newtonsoft.Json to from 6.0.4 to 8.0.3
Introduce CorrectedIsoDateTimeConverter that accept date written in ISO_8601 format with a negative or zero year
since DateTime does not support such date, returns null or DateTime.MinValue depending if it is a DateTime? or DateTime that is deserialized
