### PR TITLE
Adding report path into configuration

### DIFF
--- a/src/Maestrano.Net40.sln
+++ b/src/Maestrano.Net40.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Express 2013 for Windows Desktop
-VisualStudioVersion = 12.0.30501.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Maestrano.Net40", "Maestrano\Maestrano.Net40.csproj", "{3888E59D-F45B-405C-B8CD-039F0AF0B7CE}"
 EndProject
@@ -15,6 +15,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{FD1874
 		.nuget\NuGet.exe = .nuget\NuGet.exe
 		.nuget\NuGet.targets = .nuget\NuGet.targets
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MnoDemoApp", "..\..\demoapp-dotnet-master\MnoDemoApp\MnoDemoApp.csproj", "{B143D27E-4FDB-4972-86D8-4B63662C41C7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -30,6 +32,10 @@ Global
 		{05C58951-3A91-43D4-9169-1CE703F3023B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{05C58951-3A91-43D4-9169-1CE703F3023B}.Release|Any CPU.ActiveCfg = Debug|Any CPU
 		{05C58951-3A91-43D4-9169-1CE703F3023B}.Release|Any CPU.Build.0 = Debug|Any CPU
+		{B143D27E-4FDB-4972-86D8-4B63662C41C7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B143D27E-4FDB-4972-86D8-4B63662C41C7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B143D27E-4FDB-4972-86D8-4B63662C41C7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B143D27E-4FDB-4972-86D8-4B63662C41C7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Maestrano.Tests/Connec/ClientTest.cs
+++ b/src/Maestrano.Tests/Connec/ClientTest.cs
@@ -35,6 +35,16 @@ namespace Maestrano.Tests.Connec
         }
 
         [Test]
+        public void Get_onCollection_itReturnsTheReport()
+        {
+            RestResponse resp = this.client.GetReport("/accounts_summary");
+            var parsed = JsonConvert.DeserializeObject<Dictionary<string, object>>(resp.Content);
+
+            Assert.IsNotNull(parsed["accounts"]);
+        }
+
+
+        [Test]
         public void Get_onCollection_withType_itReturnsTheDeserializedResponse()
         {
             RestResponse<Dictionary<string, string>> resp = this.client.Get<Dictionary<string, string>>("/organizations");

--- a/src/Maestrano.Tests/Maestrano.Tests.Net40.csproj
+++ b/src/Maestrano.Tests/Maestrano.Tests.Net40.csproj
@@ -86,12 +86,6 @@
     <WCFMetadata Include="Service References\" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Maestrano\Maestrano.csproj">
-      <Project>{3888e59d-f45b-405c-b8cd-039f0af0b7ce}</Project>
-      <Name>Maestrano</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
     <None Include="Support\Saml\Responses\response1.xml.base64" />
     <None Include="Support\Saml\Responses\response2.xml.base64" />
     <None Include="Support\Saml\Responses\response3.xml.base64" />
@@ -107,6 +101,12 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Api\" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Maestrano\Maestrano.Net40.csproj">
+      <Project>{3888e59d-f45b-405c-b8cd-039f0af0b7ce}</Project>
+      <Name>Maestrano.Net40</Name>
+    </ProjectReference>
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/src/Maestrano.Tests/packages.config
+++ b/src/Maestrano.Tests/packages.config
@@ -4,5 +4,5 @@
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
   <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net45" />
-  <package id="RestSharp" version="104.4.0" targetFramework="net45" />
+  <package id="RestSharp" version="105.2.1" />
 </packages>

--- a/src/Maestrano/Configuration/Connec.cs
+++ b/src/Maestrano/Configuration/Connec.cs
@@ -11,8 +11,10 @@ namespace Maestrano.Configuration
     {
         private const string ProdDefaultApiHost = "https://api-connec.maestrano.com";
         private const string ProdDefaultBasePath = "/api/v2";
+        private const string ProdDefaultReportBasePath = "/api/reports";
         private const string TestDefaultApiHost = "http://api-sandbox.maestrano.io";
         private const string TestDefaultBasePath = "/connec/api/v2";
+        private const string TestDefaultReportBasePath = "/api/reports";
 
         private string presetName;
 
@@ -80,6 +82,32 @@ namespace Maestrano.Configuration
             }
 
             set { this["base-path"] = value; }
+        }
+
+        /// <summary>
+        /// Return the Connec! Report Base Path
+        /// </summary>
+        [ConfigurationProperty("report-base-path", DefaultValue = null, IsRequired = false)]
+        public string ReportBasePath
+        {
+            get
+            {
+                var _path = (String)this["report-base-path"];
+                if (string.IsNullOrEmpty(_path))
+                {
+                    if (MnoHelper.With(this.presetName).isProduction())
+                    {
+                        return ProdDefaultReportBasePath;
+                    }
+                    else
+                    {
+                        return TestDefaultReportBasePath;
+                    }
+                }
+                return _path;
+            }
+
+            set { this["report-base-path"] = value; }
         }
     }
 }

--- a/src/Maestrano/Connec/Client.cs
+++ b/src/Maestrano/Connec/Client.cs
@@ -116,6 +116,32 @@ namespace Maestrano.Connec
             return request;
         }
 
+        public RestResponse GetReport(string path)
+        {
+            //override base url to get report
+            var myClient = InternalClient();
+            var connecBasePath = MnoHelper.With(presetName).Connec.BasePath;
+            var reportBasePath = MnoHelper.With(presetName).Connec.ReportBasePath;
+            var connecScopedPath = connecBasePath + "/" + groupId;
+
+            myClient.BaseUrl = String.Format("{0}{1}",
+                    MnoHelper.With(presetName).Connec.Host,
+                    reportBasePath + "/" + groupId
+                    );
+            // send request
+            var request = PrepareRequest(Method.GET, path, null, null);
+            var response = (RestResponse)myClient.Execute(request);
+
+            //reset correct url 
+            myClient.BaseUrl = String.Format("{0}{1}",
+                    MnoHelper.With(presetName).Connec.Host,
+                    connecScopedPath
+                    );
+
+            //return report 
+            return response;
+        }
+
         public RestResponse Get(string path)
         {
             return (RestResponse)InternalClient().Execute(PrepareRequest(Method.GET, path, null, null));

--- a/src/Maestrano/packages.config
+++ b/src/Maestrano/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
   <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net45" />
-  <package id="RestSharp" version="104.4.0" />
+  <package id="RestSharp" version="105.2.1" />
 </packages>


### PR DESCRIPTION
@alachaum Here is the new function to access reports. I also added a new function to add the report path as configuration instead of hardcoding it. Please tell me if there are any modification to be done. 

I put the test for the report between 2 tests for the normal connec! to make sure that we test the reset of the endpoint url.
