### PR TITLE
upgraded restsharp to v105.2.3

### DIFF
--- a/src/Maestrano.Tests/Maestrano.Tests.csproj
+++ b/src/Maestrano.Tests/Maestrano.Tests.csproj
@@ -83,8 +83,9 @@
       <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\NUnit.VisualStudio.TestAdapter.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="RestSharp">
-      <HintPath>..\packages\RestSharp.104.4.0\lib\net4\RestSharp.dll</HintPath>
+    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.105.2.3\lib\net45\RestSharp.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/src/Maestrano.Tests/app.config
+++ b/src/Maestrano.Tests/app.config
@@ -201,7 +201,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="8.0.3.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/Maestrano.Tests/packages.config
+++ b/src/Maestrano.Tests/packages.config
@@ -4,5 +4,5 @@
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
   <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net45" />
-  <package id="RestSharp" version="104.4.0" targetFramework="net45" />
+  <package id="RestSharp" version="105.2.3" targetFramework="net45" />
 </packages>

--- a/src/Maestrano/Maestrano.csproj
+++ b/src/Maestrano/Maestrano.csproj
@@ -72,8 +72,9 @@
       <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\NUnit.VisualStudio.TestAdapter.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="RestSharp">
-      <HintPath>..\packages\RestSharp.104.4.0\lib\net4\RestSharp.dll</HintPath>
+    <Reference Include="RestSharp, Version=105.2.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.105.2.3\lib\net45\RestSharp.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/src/Maestrano/Net/JsonClient.cs
+++ b/src/Maestrano/Net/JsonClient.cs
@@ -6,6 +6,7 @@ using System.Collections.Specialized;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using RestSharp.Authenticators;
 
 namespace Maestrano.Net
 {
@@ -21,7 +22,7 @@ namespace Maestrano.Net
             client.AddDefaultHeader("Accept", "application/vnd.api+json");
             client.AddDefaultHeader("Content-Type", "application/vnd.api+json");
             client.Authenticator = new HttpBasicAuthenticator(key, secret);
-            client.BaseUrl = String.Format("{0}{1}", host, path);
+            client.BaseUrl = new Uri(string.Format("{0}{1}", host, path));
 
         }
 

--- a/src/Maestrano/app.config
+++ b/src/Maestrano/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="8.0.3.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/Maestrano/packages.config
+++ b/src/Maestrano/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
   <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net45" />
-  <package id="RestSharp" version="104.4.0" />
+  <package id="RestSharp" version="105.2.3" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
restsharp v104 is not compatible with v105 due to some classes changing namespaces etc. This causes issues when using Maestrano in a project that uses a newer version of restsharp.