### PR TITLE
add thirdparty property to bill API

### DIFF
--- a/src/Maestrano/Account/Bill.cs
+++ b/src/Maestrano/Account/Bill.cs
@@ -50,6 +50,9 @@ namespace Maestrano.Account
         [JsonProperty("description")]
         public string Description { get; set; }
 
+        [JsonProperty("third_party")]
+        public bool ThirdParty { get; set; }
+
         /// <summary>
         /// The Resource name
         /// </summary>
@@ -88,7 +91,7 @@ namespace Maestrano.Account
             return (new BillRequestor()).Retrieve(billId);
         }
 
-        public static Bill Create(String groupId, Int32 priceCents, String description, String currency = "AUD", Decimal? units = null, DateTime? periodStartedAt = null, DateTime? periodEndedAt = null)
+        public static Bill Create(String groupId, Int32 priceCents, String description, String currency = "AUD", Decimal? units = null, DateTime? periodStartedAt = null, DateTime? periodEndedAt = null, bool thirdParty = false)
         {
             return (new BillRequestor()).Create(
                 groupId: groupId, 
@@ -97,7 +100,8 @@ namespace Maestrano.Account
                 currency: currency,
                 units: units,
                 periodStartedAt: periodStartedAt,
-                periodEndedAt: periodEndedAt
+                periodEndedAt: periodEndedAt,
+                thirdParty: thirdParty
             );
         }
 

--- a/src/Maestrano/Account/BillRequestor.cs
+++ b/src/Maestrano/Account/BillRequestor.cs
@@ -30,7 +30,7 @@ namespace Maestrano.Account
             return MnoClient.Retrieve<Bill>(Bill.ResourcePath(), billId, presetName);
         }
 
-        public Bill Create(String groupId, Int32 priceCents, String description, String currency = "AUD", Decimal? units = null, DateTime? periodStartedAt = null, DateTime? periodEndedAt = null)
+        public Bill Create(String groupId, Int32 priceCents, String description, String currency = "AUD", Decimal? units = null, DateTime? periodStartedAt = null, DateTime? periodEndedAt = null, bool thirdParty = false)
         {
             var att = new NameValueCollection();
             att.Add("groupId", groupId);
@@ -43,7 +43,8 @@ namespace Maestrano.Account
                 att.Add("periodStartedAt", periodStartedAt.Value.ToString("s"));
             if (periodEndedAt.HasValue)
                 att.Add("periodEndedAt", periodEndedAt.Value.ToString("s"));
-
+            if (thirdParty)
+                att.Add("thirdParty", "true");
             return MnoClient.Create<Bill>(Bill.IndexPath(), att, presetName);
         }
     }


### PR DESCRIPTION
There's currently no way to mark a bill as a third party item using the SDK. It's possible using the API directly with the `third_party` parameter as per https://maestrano.atlassian.net/wiki/display/DEV/%5BDeprecated%5D+SDK-free+Integration . 
